### PR TITLE
feat(useCellRangeSelection) Add scrolling on edges while selecting cells, Updated Example.

### DIFF
--- a/examples/cell-range-selection/package.json
+++ b/examples/cell-range-selection/package.json
@@ -10,6 +10,7 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-scripts": "3.4.1",
+    "react-scroll-on-edges": "1.0.1",
     "react-table": "^7.3.2",
     "react-table-plugins": "^1.3.0",
     "styled-components": "5.1.1"

--- a/examples/cell-range-selection/src/App.js
+++ b/examples/cell-range-selection/src/App.js
@@ -1,8 +1,14 @@
-import React from "react";
-import styled from "styled-components";
-import { useTable } from "react-table";
-import { useCellRangeSelection } from "react-table-plugins";
-import makeData from "./makeData";
+import React from 'react'
+import styled from 'styled-components'
+import { useTable } from 'react-table'
+import { useCellRangeSelection } from 'react-table-plugins'
+// useScrollOnEdges: Ability to scroll on edges while you're selecting cells
+// Note: You are free to include any external lib for this usecase
+import useScrollOnEdges from 'react-scroll-on-edges'
+
+import makeData from './makeData'
+// Usage Component is for Demo purpose
+import Usage from './Usage'
 
 const Styles = styled.div`
   padding: 1rem;
@@ -37,9 +43,9 @@ const Styles = styled.div`
   pre {
     float: left;
   }
-`;
+`
 
-function Table({ columns, data }) {
+function Table ({ columns, data }) {
   // Use the state and functions returned from useTable to build your UI
   const {
     getTableProps,
@@ -49,51 +55,66 @@ function Table({ columns, data }) {
     prepareRow,
     // currentSelectedCellIds: cells of a current selected range
     // selectedCellIds: All previously selected cells
-    state: { selectedCellIds, currentSelectedCellIds },
+    state: { selectedCellIds, currentSelectedCellIds, isSelectingCells },
     // getCellsBetweenId (Fn): Pass two cell Ids to get all cell Ids between them
     getCellsBetweenId,
     setSelectedCellIds,
-    cellsById,
+    cellsById
   } = useTable(
     {
       columns,
       data,
       // cellIdSplitBy (string): Cell id is split by column.id + cellIdSplitBy + row.id
-      cellIdSplitBy: "cols_rows",
+      cellIdSplitBy: 'cols_rows',
       initialState: {
-        selectedCellIds: {},
-      },
+        selectedCellIds: {}
+      }
     },
     useCellRangeSelection
-  );
+  )
 
-  let cellsSelected = { ...currentSelectedCellIds, ...selectedCellIds };
+  let cellsSelected = { ...currentSelectedCellIds, ...selectedCellIds }
 
   // returns two random cell ids, this is just for the demo.
   const getRandomCellIds = React.useCallback(() => {
-    let cloneCellIds = Object.keys(cellsById);
+    let cloneCellIds = Object.keys(cellsById)
     let randomCellId = () =>
-      cloneCellIds[(cloneCellIds.length * Math.random()) << 0];
-    return [randomCellId(), randomCellId()];
-  }, [cellsById]);
+      cloneCellIds[(cloneCellIds.length * Math.random()) << 0]
+    return [randomCellId(), randomCellId()]
+  }, [cellsById])
 
   // getCellsBetweenId returns all cell Ids between two cell Id, and then setState for selectedCellIds
   const selectRandomCells = React.useCallback(() => {
-    const cellsBetween = getCellsBetweenId(...getRandomCellIds());
-    setSelectedCellIds(cellsBetween);
-  }, [getCellsBetweenId, setSelectedCellIds, getRandomCellIds]);
+    const cellsBetween = getCellsBetweenId(...getRandomCellIds())
+    setSelectedCellIds(cellsBetween)
+  }, [getCellsBetweenId, setSelectedCellIds, getRandomCellIds])
+
+  // 'useScrollOnEdges' hook helps us when we have height or width set to the table
+  // and when user is selecting cells and is near any of the edges, table will scroll by itself.
+  const getEdgeScrollingProps = useScrollOnEdges({
+    canAnimate: isSelectingCells // Scroll when user `isSelectingCells` is True
+    // scrollSpeed: 15, -> Optional, default is 12,
+    // edgeSize: 30     -> Optional, default is 25
+  })
 
   return (
     <>
       <button onClick={selectRandomCells}>Select cells randomly</button>
-      <div>
+      <Usage></Usage>
+      <div
+        {...getEdgeScrollingProps({
+          style: {
+            height: '400px'
+          }
+        })}
+      >
         <table {...getTableProps()}>
           <thead>
-            {headerGroups.map((headerGroup) => (
+            {headerGroups.map(headerGroup => (
               <tr {...headerGroup.getHeaderGroupProps()}>
-                {headerGroup.headers.map((column) => (
+                {headerGroup.headers.map(column => (
                   <th {...column.getHeaderProps()}>
-                    {column.render("Header")}
+                    {column.render('Header')}
                   </th>
                 ))}
               </tr>
@@ -101,91 +122,87 @@ function Table({ columns, data }) {
           </thead>
           <tbody {...getTableBodyProps()}>
             {rows.map((row, i) => {
-              prepareRow(row);
+              prepareRow(row)
               return (
                 <tr {...row.getRowProps()}>
-                  {row.cells.map((cell) => {
+                  {row.cells.map(cell => {
                     return (
                       <td
                         {...cell.getCellRangeSelectionProps()}
                         {...cell.getCellProps()}
                         style={
                           cellsSelected[cell.id]
-                            ? { backgroundColor: "#6beba8", userSelect: "none" }
-                            : { backgroundColor: "white", userSelect: "none" }
+                            ? { backgroundColor: '#6beba8', userSelect: 'none' }
+                            : { backgroundColor: 'white', userSelect: 'none' }
                         }
                       >
-                        {cell.render("Cell")}
+                        {cell.render('Cell')}
                       </td>
-                    );
+                    )
                   })}
                 </tr>
-              );
+              )
             })}
           </tbody>
         </table>
-        <pre>
-          <code>
-            {JSON.stringify(
-              { selectedCellIds, currentSelectedCellIds },
-              null,
-              2
-            )}
-          </code>
-        </pre>
       </div>
+      <pre>
+        <code>
+          {JSON.stringify({ selectedCellIds, currentSelectedCellIds }, null, 2)}
+        </code>
+      </pre>
     </>
-  );
+  )
 }
 
-function App() {
+function App () {
   const columns = React.useMemo(
     () => [
       {
-        Header: "Name1",
+        Header: 'Name1',
         columns: [
           {
-            Header: "First Name",
-            accessor: "firstName",
+            Header: 'First Name',
+            accessor: 'firstName'
           },
           {
-            Header: "Last Name",
-            accessor: "lastName",
-          },
-        ],
+            Header: 'Last Name',
+            accessor: 'lastName'
+          }
+        ]
       },
       {
-        Header: "Info",
+        Header: 'Info',
         columns: [
           {
-            Header: "Age",
-            accessor: "age",
+            Header: 'Age',
+            accessor: 'age'
           },
           {
-            Header: "Visits",
-            accessor: "visits",
+            Header: 'Visits',
+            accessor: 'visits'
           },
           {
-            Header: "Status",
-            accessor: "status",
+            Header: 'Status',
+            accessor: 'status'
           },
           {
-            Header: "Profile Progress",
-            accessor: "progress",
-          },
-        ],
-      },
+            Header: 'Profile Progress',
+            accessor: 'progress'
+          }
+        ]
+      }
     ],
     []
-  );
+  )
 
-  const data = React.useMemo(() => makeData(20), []);
+  const data = React.useMemo(() => makeData(20), [])
 
   return (
     <Styles>
       <Table columns={columns} data={data} />
     </Styles>
-  );
+  )
 }
 
-export default App;
+export default App

--- a/examples/cell-range-selection/src/Usage.js
+++ b/examples/cell-range-selection/src/Usage.js
@@ -1,0 +1,43 @@
+import React from 'react'
+
+const Usage = () => {
+  const [show, setshow] = React.useState(false)
+
+  const ShowInfo = () => {
+    return (
+      <>
+        <ul>
+          <li>
+            Mouse drag - Click the mouse and drag to select a cell range and
+            this will clear any existing selected cells/ranges
+            <li>
+              Ctrl + Mouse drag - Holding Ctr and Mouse drag will select
+              multiple cell ranges and this keeps all existing selected
+              cells/ranges
+            </li>
+            <li>
+              Ctrl + click - For cell selection and this keeps all existing
+              selected cells/ranges
+            </li>
+          </li>
+        </ul>
+        <p>
+          <code>getEdgeScrollingProps()</code>: Start selecting cell range and
+          move near edges, table scrolls for you.
+        </p>
+      </>
+    )
+  }
+
+  return (
+    <>
+      {' '}
+      <button onClick={() => setshow(o => !o)}>
+        <span title='More Info'>💡</span>
+      </button>
+      {show && <ShowInfo></ShowInfo>}
+    </>
+  )
+}
+
+export default Usage

--- a/examples/cell-range-selection/yarn.lock
+++ b/examples/cell-range-selection/yarn.lock
@@ -8817,10 +8817,15 @@ react-scripts@3.4.1:
   optionalDependencies:
     fsevents "2.1.2"
 
-react-table-plugins@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/react-table-plugins/-/react-table-plugins-1.3.0.tgz#b1cf202103dcd04287724b29e81df6edd3c68d95"
-  integrity sha512-prX/88fBwIt3RQfi/jyRmlRyDcOr4JBNs1t52ucqCGqI8XrD+Kj6VdRw6TYtwk5iXOWOeyzsTaYDeHg4hDGfsw==
+react-scroll-on-edges@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/react-scroll-on-edges/-/react-scroll-on-edges-1.0.1.tgz#0b59f2f86880b09a63ae324c9554be61f2d1e727"
+  integrity sha512-MYH/o/MaBcPijx0Lxpnlv/u5jlnMhzudU4yWbHbrBQp/XzP6VVjuePBpTRohy4pJpHdY88KiDcQRFPZTeBtkbg==
+
+react-table-plugins@^1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/react-table-plugins/-/react-table-plugins-1.3.1.tgz#5d0d106acd43f49c38c8b15599d4a3e50d99a7a6"
+  integrity sha512-LFCTAcqCSh4VnNjukarrkSb+xuKufIuL77Wk46Kayy3R0Ggqatxj0LDqCw5jBkVggOGM1kMPrgFkR9xYjsXldA==
 
 react-table@^7.3.2:
   version "7.3.2"


### PR DESCRIPTION
Hi @gargroh, 

- [x] Issue #18 
- [x] `Usage` component in an example, User can have easier access to usage(docs) while they're on code sandbox. We can remove it if it's not needed

***
 
I wrote a custom hook for it [react-scroll-on-edges](https://github.com/07harish/React-scroll-on-edges) : Ability to scroll on edges

`const getEdgeScrollingProps = useScrollOnEdges()`

useScrollOnEdges() - Returns prop getter, which can be applied to HTML elements.

> useScrollOnEdges also takes an **optional** parameter as an object with three props
> ```
> useScrollOnEdges ({
>  canAnimate: boolean | true (default),
>  scrollSpeed: number | 12 (default),
>  edgeSize: number | 30 (default)
> })
> ```

The user is free to decide whether he wants to include it or not. This feature makes `useCellRangeSelection` more effective. Enjoyed working on this 💯 