### PR TITLE
Update links-test.yml

### DIFF
--- a/.github/workflows/links-test.yml
+++ b/.github/workflows/links-test.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1
-      - uses: urlstechie/urlchecker-action@0.2.1
+      - uses: urlstechie/urlchecker-action@0.0.27
         with:
           # A subfolder or path to navigate to in the present or cloned repository
           subfolder: /github/workspace/


### PR DESCRIPTION
We are going to be deprecating older versions of urlchecker (and there was a change in versioning to match the upstream package so the version only appears earlier) so I wanted to update here to make sure your workflows do not break! To be clear, 0.0.27 is actually the newest release. https://github.com/urlstechie/urlchecker-action/releases/tag/0.0.27

The updated versions also run about 7x as fast, so that's an added bonus!